### PR TITLE
fix: Add ability to set locale options

### DIFF
--- a/lib/coprl/presenters/plugins/chart/component.rb
+++ b/lib/coprl/presenters/plugins/chart/component.rb
@@ -11,7 +11,7 @@ module Coprl
             super(type: :chart, **attribs_, &block)
             @chart_options = {}
             %i(line spline step area area-spline area-step bar scatter pie donut gauge
-               data axis color size grid regions legend tooltip padding transition point).each do |setting|
+               data axis color size grid regions legend tooltip padding transition point locale).each do |setting|
               value = attribs.delete(setting)
               @chart_options.merge!(setting=>value) if value
             end

--- a/views/chart/chart.js
+++ b/views/chart/chart.js
@@ -1,9 +1,13 @@
 class Chart {
   constructor(element) {
     this.data = JSON.parse(element.dataset.chartOptions);
-    if (this.data.axis && this.data.axis.y && this.data.axis.y.tick &&
-        this.data.axis.y.tick.format) {
-      this.data.axis.y.tick.format = d3.format(this.data.axis.y.tick.format)
+    if (this.data.axis && this.data.axis.y && this.data.axis.y.tick && this.data.axis.y.tick.format) {
+      if (this.data.locale) {
+        const d3Format = d3.formatLocale(this.data.locale);
+        this.data.axis.y.tick.format = d3Format.format(this.data.axis.y.tick.format)
+      } else {
+        this.data.axis.y.tick.format = d3.format(this.data.axis.y.tick.format)
+      }
     }
     this.chart = c3.generate(Object.assign({bindto: element}, this.data));
   }


### PR DESCRIPTION
Adds a locale option where the formatting of the y-axis can be customized.

```
chart data: {...},
         locale: {
            currency: ["£", ""],
            decimal: ".",
            thousands: ","
          }
```

[https://github.com/d3/d3-format/blob/v3.1.0/README.md#formatDefaultLocale](https://github.com/d3/d3-format/blob/v3.1.0/README.md#formatDefaultLocale)